### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/contracts/DODOToken/DODOIncentive.sol
+++ b/contracts/DODOToken/DODOIncentive.sol
@@ -65,17 +65,17 @@ contract DODOIncentive is InitializableOwnable {
     function changePerReward(uint256 _dodoPerBlock) public onlyOwner {
         _updateTotalReward();
         dodoPerBlock = _dodoPerBlock;
-        emit SetPerReward(dodoPerBlock);
+        emit SetPerReward(_dodoPerBlock);
     }
 
     function changeDefaultRate(uint256 _defaultRate) public onlyOwner {
         defaultRate = _defaultRate;
-        emit SetDefaultRate(defaultRate);
+        emit SetDefaultRate(_defaultRate);
     }
 
     function changeDODOProxy(address _dodoProxy) public onlyOwner {
         _DODO_PROXY_ = _dodoProxy;
-        emit SetNewProxy(_DODO_PROXY_);
+        emit SetNewProxy(_dodoProxy);
     }
 
     function emptyReward(address assetTo) public onlyOwner {

--- a/contracts/DODOToken/DODOMineV3/RewardVault.sol
+++ b/contracts/DODOToken/DODOMineV3/RewardVault.sol
@@ -54,6 +54,6 @@ contract RewardVault is Ownable {
         _TOTAL_REWARD_ = _TOTAL_REWARD_.add(rewardInput);
         _REWARD_RESERVE_ = rewardBalance;
 
-        emit DepositReward(_TOTAL_REWARD_, rewardInput, _REWARD_RESERVE_);
+        emit DepositReward(_TOTAL_REWARD_, rewardInput, rewardBalance);
     }
 }

--- a/contracts/DODOToken/vDODOToken.sol
+++ b/contracts/DODOToken/vDODOToken.sol
@@ -120,7 +120,7 @@ contract vDODOToken is InitializableOwnable {
 
     function updateDODOFeeBurnRatio(uint256 dodoFeeBurnRatio) public onlyOwner {
         _DODO_FEE_BURN_RATIO_ = dodoFeeBurnRatio;
-        emit UpdateDODOFeeBurnRatio(_DODO_FEE_BURN_RATIO_);
+        emit UpdateDODOFeeBurnRatio(dodoFeeBurnRatio);
     }
 
     function updateDODOCirculationHelper(address helper) public onlyOwner {


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.