### PR TITLE
fix dsp init quote check

### DIFF
--- a/contracts/DODOStablePool/impl/DSPFunding.sol
+++ b/contracts/DODOStablePool/impl/DSPFunding.sol
@@ -44,6 +44,7 @@ contract DSPFunding is DSPVault {
         // But May Happen，reserve >0 But totalSupply = 0
         if (totalSupply == 0) {
             // case 1. initial supply
+            require(quoteBalance > 0, "ZERO_QUOTE_AMOUNT");
             shares = quoteBalance < DecimalMath.mulFloor(baseBalance, _I_)
                 ? DecimalMath.divFloor(quoteBalance, _I_)
                 : baseBalance;


### PR DESCRIPTION
fix immunefi bug.

Details:
first depositor can call totalSupply() with quoteRserve==0 and so the "else if" conditions will be false when other calls the buyShares() the share amount will be 0 and code would revert with "MINT_AMOUNT_NOT_ENOUGH" error.

When we create pools, we use the creation method in DSPProxy. When users create pools on the frontend, the frontend checks the deposit amount of the quote token, which cannot be zero at minimum. This griefing attack will not occur when users normally use the product in online version. Therefore, there is no need to update current template